### PR TITLE
New lazy-load version

### DIFF
--- a/.jshintrc
+++ b/.jshintrc
@@ -11,5 +11,12 @@
   "unused": true,
   "boss": true,
   "eqnull": true,
-  "node": true
+  "node": true,
+  "esnext": true,
+  "globals": {
+    "suite": false,
+    "test": false,
+    "setup": false,
+    "teardown": false
+  }
 }

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ _The Api has been changed to extend the grunt object, rather than provide a new 
 ## Getting Started
 Install the module with: `npm install grunt-lazyload --save`
 
-```javascript
+```js
 require('grunt-lazyload')(grunt);
 
 grunt.lazyLoadNpmTasks('grunt-contrib-jshint', 'jshint');
@@ -34,29 +34,55 @@ Not everyone is using grunt the same way, but if you want your grunt to run a li
 
 ## Examples
 ### Adding lazyloading to grunt:
-```javascript
+```js
 require('grunt-lazyload')(grunt);
 ```
-This is not truely a gruntplugin but a node module that adds an extra method to grunt to allow lazy loading so you have to pass it an instance of grunt for it to modify
+This is not truly a grunt plugin, but a node module that adds extra methods to `grunt` to allow lazy loading. Pass the instance of grunt you intend to extend.
 
-### Lazy loading a library with a single task:
-```javascript
+### Lazy loading an NPM library with a single task:
+```js
 grunt.lazyLoadNpmTasks('grunt-contrib-jshint', 'jshint');
 ```
 
-### Lazy loading a library with multiple tasks:
-```javascript
+### Lazy loading an NPM library with multiple tasks:
+```js
 grunt.lazyLoadNpmTasks('grunt-some-plugin', ['task1', 'task2', 'task3']);
 ```
 
-You must provide the task names that the plugin will define ahead of time.
+### Lazy loading tasks from a local directory:
+```js
+grunt.lazyLoadTasks('localdir/tasks', {
+  'grunt-custombuild.js': 'custombuild',
+  'grunt-deploy.js': ['deploy'],
+  'grunt-customclean.js': ['clean', 'cleanall', 'reset'],
+});
+```
+
+In order to initialize lazy loading, you must define ahead of time the possible task names and where to load them from. For
+`lazyLoadNpmTasks`, specify the task (or tasks) that are provided by that NPM module. For a local directory of tasks,
+provide a hash, where each key is the _exact filename_ containing the tasks, and the value is the task (or tasks) it provides.
+
+### Task renaming
+
+```js
+grunt.lazyLoadNpmTasks('grunt-contrib-copy', 'copy');
+grunt.renameTask('copy', 'classic-copy');
+
+// Later
+grunt.task.run('classic-copy:somefiles');
+```
+
+Task renames are automatically tracked by the lazy loader and saved for later resolution. In this example, when you
+attempt to run `classic-copy`, the lazy loader will load `grunt-contrib-copy` and register the `copy` task as `classic-copy`.
+
+Automatic task renaming works for both NPM tasks and local task directories.
 
 ## Contributing
 In lieu of a formal styleguide, take care to maintain the existing coding style. Add unit tests for any new or changed functionality. Lint and test your code using [Grunt](http://gruntjs.com/).
 
 ## Release History
 * 5/10/2014  - 1.0.3 (eagerload for -h) - [PR#5](https://github.com/raphaeleidus/grunt-lazyload/pull/5)
-* 2/17/2014  - 1.0.2 (jshint error cleanup - [PR#4](https://github.com/raphaeleidus/grunt-lazyload/pull/4)) 
+* 2/17/2014  - 1.0.2 (jshint error cleanup - [PR#4](https://github.com/raphaeleidus/grunt-lazyload/pull/4))
 * 2/4/2014   - 1.0.1 (eagerload for the --help screen)
 * 2/4/2014   - 1.0.0 (simplify code and improve api)
 * 2/3/2014   - 0.2.2 (fix multitarget/paramater passing bug)

--- a/lib/grunt-lazyload.js
+++ b/lib/grunt-lazyload.js
@@ -143,7 +143,7 @@ class LazyLoader {
 
   loadAndRun(directory, filename, taskname, ...args) {
       this.load(directory, filename);
-      this.grunt.task.run([taskname, ...args].join(":"));
+      this.grunt.task.run([taskname, ...args].join(':'));
   }
 }
 

--- a/lib/grunt-lazyload.js
+++ b/lib/grunt-lazyload.js
@@ -10,13 +10,6 @@
 
 class LazyLoader {
   constructor(grunt) {
-    // Abort the rest of lazy-load installation if we are listing task descriptions
-    if (grunt.option('h') || grunt.option('help')) {
-      grunt.lazyLoadTasks = (tasksdir) => grunt.loadTasks(tasksdir);
-      grunt.lazyLoadNpmTasks = (modulename) => grunt.loadNpmTasks(modulename);
-      return;
-    }
-
     // Instance of grunt this lazy loader is installed under
     this.grunt = grunt;
 
@@ -50,7 +43,7 @@ class LazyLoader {
     };
 
     // Lazy-load wrapper for registerTask
-    const $registerTask = grunt.registerTask;
+    const $registerTask = grunt.task.registerTask;
     grunt.registerTask = (...args) => {
       // If lazy load is registering grunt tasks and it matches the directory, filename, and
       // task name of a known alias, replace the task name with the alias name.
@@ -65,7 +58,7 @@ class LazyLoader {
     grunt.task.registerTask = grunt.registerTask;
 
     // Lazy-load wrapper for registerMultiTask
-    const $registerMultiTask = grunt.registerMultiTask;
+    const $registerMultiTask = grunt.task.registerMultiTask;
     grunt.registerMultiTask = (...args) => {
       // If lazy load is registering grunt tasks and it matches the directory, filename, and
       // task name of a known alias, replace the task name with the alias name.
@@ -84,6 +77,11 @@ class LazyLoader {
   }
 
   registerTasks(tasksdir, taskdefs) {
+    // If listing tasks, eager-load everything
+    if (this.grunt.option('help') || this.grunt.option('h')) {
+      return this.grunt.loadTasks(tasksdir);
+    }
+
     if (tasksdir) {
       tasksdir = require('path').resolve(tasksdir);
       if (!this.grunt.file.exists(tasksdir)) {
@@ -93,14 +91,20 @@ class LazyLoader {
     }
 
     Object.keys(taskdefs).forEach(filename => {
-      taskdefs[filename].forEach(taskname => {
+      let list = Array.isArray(taskdefs[filename]) ? taskdefs[filename] : [taskdefs[filename]];
+      list.forEach(taskname => {
         this.registerLazyLoadTask(tasksdir, filename, taskname, taskname);
       });
     });
   }
 
   registerNpmTasks(modulename, tasklist) {
-    this.registerTasks(undefined, { modulename: tasklist });
+    // If listing tasks, eager-load everything
+    if (this.grunt.option('help') || this.grunt.option('h')) {
+      return this.grunt.loadNpmTasks(modulename);
+    }
+
+    this.registerTasks(undefined, { [modulename]: tasklist });
   }
 
   registerLazyLoadTask(directory, filename, taskname, aliasname) {
@@ -111,7 +115,7 @@ class LazyLoader {
 
     const target = this.loadAndRun.bind(this, directory, filename, aliasname);
     target.alias = true; // hide double-header output in grunt log
-    this.grunt.registerTask(aliasname, target);
+    this.grunt.registerTask(aliasname, aliasname, target);
     this.pending[aliasname] = { directory, filename };
   }
 
@@ -120,16 +124,21 @@ class LazyLoader {
   }
 
   load(directory, filename) {
+    this.taskList[`${directory}:${filename}`].forEach(taskname => {
+      delete this.pending[taskname];
+      this.grunt.task.renameTask(taskname, `##${taskname}##`);
+    });
+
     try {
       this.loadingFile = { directory, filename };
-      this._require(directory ? `${directory}/${filename}` : filename)(this.grunt);
+      if (directory) {
+        this._require(`${directory}/${filename}`)(this.grunt);
+      } else {
+        this.grunt.loadNpmTasks(filename);
+      }
     } finally {
       this.loadingFile = undefined;
     }
-
-    this.taskList[`${directory}:${filename}`].forEach(taskname => {
-      delete this.pending[taskname];
-    });
   }
 
   loadAndRun(directory, filename, taskname, ...args) {

--- a/lib/grunt-lazyload.js
+++ b/lib/grunt-lazyload.js
@@ -8,33 +8,146 @@
 
 'use strict';
 
-var util = require('util');
-var argv = process.argv;
-
-module.exports = function(grunt) {
-  grunt.lazyLoadNpmTasks = function lazyload(NpmPackage, tasks) {
-    //when displaying the grunt help eager load everything
-    if(argv.indexOf('--help') !== -1 || argv.indexOf('-h') !== -1) {
-      grunt.loadNpmTasks(NpmPackage);
+class LazyLoader {
+  constructor(grunt) {
+    // Abort the rest of lazy-load installation if we are listing task descriptions
+    if (grunt.option('h') || grunt.option('help')) {
+      grunt.lazyLoadTasks = (tasksdir) => grunt.loadTasks(tasksdir);
+      grunt.lazyLoadNpmTasks = (modulename) => grunt.loadNpmTasks(modulename);
       return;
     }
-    if(!util.isArray(tasks)) {
-      tasks = [tasks];
+
+    // Instance of grunt this lazy loader is installed under
+    this.grunt = grunt;
+
+    // Keep track of all tasks that can be lazy-loaded, and what directory/filename
+    // to load them from. Once loaded, the task will be removed from this list.
+    this.pending = {};
+
+    // Keep track of all modules we know about, and the tasks we expect to register
+    // in each (a module can register more than one task).
+    this.taskList = {};
+
+    // Keep a list of directory/file/task entries and the desired alias for each task.
+    // Normally, the desired alias is simply the task name, but this pairing will be
+    // updated if you rename a task before it is loaded.
+    this.aliasList = {};
+
+    // A state marker used to indicate we are actively loading a grunt task module. If
+    // set, any tasks registered will be checked against the alias list above.
+    this.loadingFile = undefined;
+
+    // Lazy-load wrapper for renameTask
+    const $renameTask = grunt.task.renameTask;
+    grunt.task.renameTask = (oldName, newName) => {
+      const entry = this.pending[oldName];
+      if (entry) {
+        delete this.pending[oldName];
+        this.registerLazyLoadTask(entry.directory, entry.filename, oldName, newName);
+      } else {
+        $renameTask(oldName, newName);
+      }
+    };
+
+    // Lazy-load wrapper for registerTask
+    const $registerTask = grunt.registerTask;
+    grunt.registerTask = (...args) => {
+      // If lazy load is registering grunt tasks and it matches the directory, filename, and
+      // task name of a known alias, replace the task name with the alias name.
+      if (this.loadingFile) {
+        const key = `${this.loadingFile.directory}:${this.loadingFile.filename}:${args[0]}`;
+        if (this.aliasList[key]) {
+          args[0] = this.aliasList[key];
+        }
+      }
+      $registerTask(...args);
+    };
+    grunt.task.registerTask = grunt.registerTask;
+
+    // Lazy-load wrapper for registerMultiTask
+    const $registerMultiTask = grunt.registerMultiTask;
+    grunt.registerMultiTask = (...args) => {
+      // If lazy load is registering grunt tasks and it matches the directory, filename, and
+      // task name of a known alias, replace the task name with the alias name.
+      if (this.loadingFile) {
+        const key = `${this.loadingFile.directory}:${this.loadingFile.filename}:${args[0]}`;
+        if (this.aliasList[key]) {
+          args[0] = this.aliasList[key];
+        }
+      }
+      $registerMultiTask(...args);
+    };
+    grunt.task.registerMultiTask = grunt.registerMultiTask;
+
+    grunt.lazyLoadTasks = this.registerTasks.bind(this);
+    grunt.lazyLoadNpmTasks = this.registerNpmTasks.bind(this);
+  }
+
+  registerTasks(tasksdir, taskdefs) {
+    if (tasksdir) {
+      tasksdir = require('path').resolve(tasksdir);
+      if (!this.grunt.file.exists(tasksdir)) {
+        this.grunt.log.error('Tasks directory "' + tasksdir + '" not found.');
+        return;
+      }
     }
-    tasks.forEach(function(task) {
-      //register the task aliases
-      grunt.task.registerTask(task, task, function(){
-        //pass along any arguments passed in
-        var runName = Array.prototype.concat.apply([task], arguments).join(':');
-        tasks.forEach(function(t) {
-          //rename all the aliases (grunt doesn't have a task.delete ... yet)
-          grunt.task.renameTask(t, '_'+t+'_');
-        });
-        //register the true tasks
-        grunt.loadNpmTasks(NpmPackage);
-        //run the task
-        grunt.task.run(runName);
+
+    Object.keys(taskdefs).forEach(filename => {
+      taskdefs[filename].forEach(taskname => {
+        this.registerLazyLoadTask(tasksdir, filename, taskname, taskname);
       });
     });
-  };
+  }
+
+  registerNpmTasks(modulename, tasklist) {
+    this.registerTasks(undefined, { modulename: tasklist });
+  }
+
+  registerLazyLoadTask(directory, filename, taskname, aliasname) {
+    const filekey = `${directory}:${filename}`;
+    this.aliasList[`${filekey}:${taskname}`] = aliasname;
+    this.taskList[filekey] = this.taskList[filekey] || [];
+    this.taskList[filekey].push(aliasname);
+
+    const target = this.loadAndRun.bind(this, directory, filename, aliasname);
+    target.alias = true; // hide double-header output in grunt log
+    this.grunt.registerTask(aliasname, target);
+    this.pending[aliasname] = { directory, filename };
+  }
+
+  _require(filename) {
+    return require(filename);
+  }
+
+  load(directory, filename) {
+    try {
+      this.loadingFile = { directory, filename };
+      this._require(directory ? `${directory}/${filename}` : filename)(this.grunt);
+    } finally {
+      this.loadingFile = undefined;
+    }
+
+    this.taskList[`${directory}:${filename}`].forEach(taskname => {
+      delete this.pending[taskname];
+    });
+  }
+
+  loadAndRun(directory, filename, taskname, ...args) {
+      this.load(directory, filename);
+      this.grunt.task.run([taskname, ...args].join(":"));
+  }
+}
+
+const lazyLoader = {
+  _instances: new Map(),
+  install(grunt) {
+    let instance = lazyLoader._instances.get(grunt);
+    if (!instance) {
+      instance = new LazyLoader(grunt);
+      lazyLoader._instances.set(grunt, instance);
+    }
+    return instance;
+  }
 };
+
+module.exports = (grunt) => lazyLoader.install(grunt);

--- a/package.json
+++ b/package.json
@@ -22,15 +22,15 @@
   ],
   "main": "lib/grunt-lazyload",
   "engines": {
-    "node": ">= 0.8.0"
+    "node": ">= 8.0.0"
   },
   "scripts": {
     "test": "grunt mochacli"
   },
   "devDependencies": {
+    "grunt": "~0.4.2",
     "grunt-contrib-jshint": "~0.8.0",
     "grunt-contrib-watch": "~0.5.3",
-    "grunt": "~0.4.2",
     "grunt-mocha-cli": "~1.6.0"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "grunt-lazyload",
   "description": "Gruntplugin Lazy Loading",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "homepage": "https://github.com/raphaeleidus/grunt-lazyload",
   "author": {
     "name": "Raphael Eidus",

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   },
   "devDependencies": {
     "grunt": "~0.4.2",
-    "grunt-contrib-jshint": "~0.8.0",
+    "grunt-contrib-jshint": "^2.1.0",
     "grunt-contrib-watch": "~0.5.3",
     "grunt-mocha-cli": "~1.6.0"
   },

--- a/test/grunt-lazyload_test.js
+++ b/test/grunt-lazyload_test.js
@@ -80,7 +80,7 @@ suite('lazyloader', function() {
     instance._require = function (packageName) {
       return function(grunt) {
         grunt._loadTasks(packageName);
-      }
+      };
     };
     $pathresolve = path.resolve;
     path.resolve = filepath => `resolved/${filepath}`;


### PR DESCRIPTION
### SUMMARY

Add some new features, bump required node version up to `8.0.0`, and release as a new major version. Fixes #7.

### DETAILS

#### `lazyLoadTasks`

A new lazy-load implementation of `loadTasks` (which loads all files containing grunt tasks from a local directory).

This implementation allows the user to specify the various files in the folder and which tasks will be loaded by each one.  See README updates for syntax.

#### `lazyLoadNpmTasks`

The engine behind the scenes has changed, but the existing API hasn't changed (anyone using the old `grunt-lazyload` should be able to upgrade with zero changes, as long as they are on node v8+).

#### `renameTask`

The lazy loader now tracks task renames for pending tasks, allowing you to perform multiple renames on tasks that aren't loaded yet and have them behave as expected when you run them.

### TESTS

* Existing tests tweaked due to the new behavior of the lazy loader (some assumptions changed).
* Tests added for new functionality.
